### PR TITLE
Revert to mod_python 3.3.1 semantics where cookie expiration is sent to client

### DIFF
--- a/lib/python/mod_python/Cookie.py
+++ b/lib/python/mod_python/Cookie.py
@@ -59,7 +59,7 @@ class metaCookie(type):
 
         _valid_attr = (
             "version", "path", "domain", "secure",
-            "comment", "max_age",
+            "comment", "expires", "max_age",
             # RFC 2965
             "commentURL", "discard", "port",
             # Microsoft Extension


### PR DESCRIPTION
Without the "expires" attribute in the _valid_attr list, cookie expirations are never returned by the __str__ method, and consequently are never sent to the browser.
