### PR TITLE
Fixed problem where BSD-incompatible install command had been chosen.

### DIFF
--- a/configure
+++ b/configure
@@ -2829,7 +2829,6 @@ case $as_dir/ in
 	    rm -rf conftest.one conftest.two conftest.dir
 	    echo one > conftest.one
 	    echo two > conftest.two
-	    mkdir conftest.dir
 	    if "$as_dir/$ac_prog$ac_exec_ext" -c conftest.one conftest.two "`pwd`/conftest.dir" &&
 	      test -s conftest.one && test -s conftest.two &&
 	      test -s conftest.dir/conftest.one &&


### PR DESCRIPTION
In my Ubuntu 13.10 system, because of this line, BSD-incompatible native /usr/bin/install command had been incorrectly chosen.
This caused "make install" to fail complaining about missing parent directories.

Removing this line makes the following test fail and install-sh is chosen instead.
