### PR TITLE
Test fail if MPMs loaded modularly

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -310,7 +310,12 @@ class HttpdCtrl:
         modpath = LIBEXECDIR
 
         s = Container(
-            LoadModule("mpm_prefork_module modules/mod_mpm_prefork.so"),
+            IfModule("!prefork.c",
+            IfModule("!worker.c",
+            IfModule("!perchild.c",
+            IfModule("!mpm_winnt.c",
+                     LoadModule("mpm_prefork_module modules/mod_mpm_prefork.so"),
+            )))),
             IfModule("prefork.c",
                      StartServers("3"),
                      MaxSpareServers("1")),


### PR DESCRIPTION
This is inelegant, but if none of the MPMs you have listed are compiled it, it makes an attempt to load prefork. Otherwise, your test Apache won't load at all on systems with modular MPMs.
