### PR TITLE
Accept APXSFLAGS argument to apxs

### DIFF
--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -54,7 +54,7 @@ mod_python.so: $(SRCS) @SOLARIS_HACKS@
 	@echo
 	@echo 'Building mod_python.so.'
 	@echo
-	$(APXS) $(INCLUDES) $(CPPFLAGS) $(CFLAGS) -c $(SRCS) $(LDFLAGS) $(LDLIBS) @SOLARIS_HACKS@
+	$(APXS) $(INCLUDES) $(CPPFLAGS) $(APXSFLAGS) $(CFLAGS) -c $(SRCS) $(LDFLAGS) $(LDLIBS) @SOLARIS_HACKS@
 	@rm -f mod_python.so
 	@ln -s .libs/mod_python.so mod_python.so
 clean:


### PR DESCRIPTION
We need to be able to pass in some extra flags to the APXS compile line (namely -Wc,-fno-strict-aliasing).  This allows that.