### PR TITLE
simple bug fix in Session.py >> DbmSesssion >> dbm_cleanup for conflicting use of dbm variable

### DIFF
--- a/lib/python/mod_python/Session.py
+++ b/lib/python/mod_python/Session.py
@@ -338,9 +338,9 @@ def unlock_session_cleanup(sess):
 ## DbmSession
 
 def dbm_cleanup(data):
-    dbm, server = data
+    filename, server = data
     _apache._global_lock(server, None, 0)
-    db = dbm.open(dbm, 'c')
+    db = dbm.open(filename, 'c')
     try:
         old = []
         s = db.first()

--- a/lib/python/mod_python/Session.py
+++ b/lib/python/mod_python/Session.py
@@ -124,7 +124,7 @@ def _new_sid(req):
     g = _get_generator()
     rnd1 = g.randint(0, 999999999)
     rnd2 = g.randint(0, 999999999)
-    ip = req.connection.remote_ip
+    ip = req.connection.client_ip
 
     return md5_hash("%d%d%d%d%s" % (t, pid, rnd1, rnd2, ip))
 

--- a/lib/python/mod_python/psp.py
+++ b/lib/python/mod_python/psp.py
@@ -29,6 +29,8 @@ from cgi import escape
 import dbm, dbm
 import tempfile
 
+PY2 = sys.version[0] == '2'
+
 # dbm types for cache
 dbm_types = {}
 
@@ -268,7 +270,10 @@ class PSP:
                     # run error page
                     psp.error_page.run({"exception": (et, ev, etb)}, flush)
                 else:
-                    raise et(ev).with_traceback(etb)
+                    if PY2:
+                        raise et, ev, etb
+                    else:
+                        raise et(ev).with_traceback(etb)
         finally:
             # if session was created here, unlock it and don't leave
             # it behind in request object in unlocked state as it


### PR DESCRIPTION
The variable "dbm" was used for both the name of dbm file and the dbm module in Session.py >> DbmSesssion >> dbm_cleanup.  The simple fix was to use a new variable "filename" for the name of the dbm file.