### PR TITLE
Python3: fix SyntaxError in psp.py #61

### DIFF
--- a/lib/python/mod_python/psp.py
+++ b/lib/python/mod_python/psp.py
@@ -271,7 +271,7 @@ class PSP:
                     psp.error_page.run({"exception": (et, ev, etb)}, flush)
                 else:
                     if PY2:
-                        raise et, ev, etb
+                        exec('raise et, ev, etb')
                     else:
                         raise et(ev).with_traceback(etb)
         finally:


### PR DESCRIPTION
Python2's test code (using `mock` package):

```python
import os
import sys
import traceback
import unittest
from mock import MagicMock, patch
sys.modules['_apache'] = MagicMock()
from .psp import PSP


class TestRaiseException(unittest.TestCase):
    def test_run(self):
        with open('_psp.py', mode='w') as f:
            f.write('def parsestring(args): return args\n')

        sut = PSP(MagicMock(filename='dummy'), string='foo')
        with self.assertRaises(NameError):
            sut.run()
        et, ev, etb = sys.exc_info()
        
        self.assertEqual(ev.message, "name 'foo' is not defined")
        actual = traceback.format_tb(etb)
        self.assertIn('File "__psp__",', actual[-1])
        self.assertIn('in <module>', actual[-1])
        self.assertIn('File "mod_python/psp.py"', actual[-2])
        self.assertIn('exec(code, global_scope)', actual[-2])

        os.remove('_psp.py')


if __name__ == '__main__':
    unittest.main()
```

dummy files for test:

- `_psp.py`

```python
def parsestring(args):
    return args
```

- `version.py`

```python
version = ''
```


run test:

```
$ pwd
/path/to/lib/python

$ python -m mod_python.test_psp
.
----------------------------------------------------------------------
Ran 1 test in 0.011s

OK
```