### PR TITLE
Fallback for parse qsl

### DIFF
--- a/lib/python/mod_python/util.py
+++ b/lib/python/mod_python/util.py
@@ -399,17 +399,13 @@ class FieldStorage:
 
     def parse_qsl_safely(self, query_string, keep_blank_values):
         """
-        This Function checks whether this script is compiled with python2 or python3
-        if script is compiled with python2, then the script runs parse_qsl and returns the output 
-        if the script is compiled with python3, then it calls urllib.parse.parse_qsl if there is exception in processing parse_qsl function
+        This script calls urllib.parse.parse_qsl if there is exception in processing parse_qsl function
 
         :param query_string: The query string which needs to be parsed
         :type query_string: string
         :param keep_blank_values: keep_blank_values is a flag indicating whether blank values in percent-encoded queries should be treated as blank strings.
         :type keep_blank_values: int/boolean
         """
-        if PY2:
-            return parse_qsl(query_string, keep_blank_values)
         try:
             pairs = parse_qsl(query_string, keep_blank_values)
         except SystemError as er:

--- a/lib/python/mod_python/util.py
+++ b/lib/python/mod_python/util.py
@@ -249,7 +249,7 @@ class FieldStorage:
 
         # always process GET-style parameters
         if req.args:
-            pairs = parse_qsl(req.args, keep_blank_values)
+            pairs = self.parse_qsl_safely(req.args, keep_blank_values)
             for pair in pairs:
                 self.add_field(pair[0], pair[1])
 
@@ -274,7 +274,7 @@ class FieldStorage:
             v = req.read(clen)
             if not isinstance(v, bytes):
                 raise TypeError("req.read() must return bytes")
-            pairs = parse_qsl(v, keep_blank_values)
+            pairs = self.parse_qsl_safely(v, keep_blank_values)
             for pair in pairs:
                 self.add_field(pair[0], pair[1])
             return
@@ -396,6 +396,26 @@ class FieldStorage:
             field.disposition_options = disp_options
             field.headers = headers
             self.list.append(field)
+
+    def parse_qsl_safely(self, query_string, keep_blank_values):
+        """
+        This Function checks whether this script is compiled with python2 or python3
+        if script is compiled with python2, then the script runs parse_qsl and returns the output 
+        if the script is compiled with python3, then it calls urllib.parse.parse_qsl if there is exception in processing parse_qsl function
+
+        :param query_string: The query string which needs to be parsed
+        :type query_string: string
+        :param keep_blank_values: keep_blank_values is a flag indicating whether blank values in percent-encoded queries should be treated as blank strings.
+        :type keep_blank_values: int/boolean
+        """
+        if PY2:
+            return parse_qsl(query_string, keep_blank_values)
+        try:
+            pairs = parse_qsl(query_string, keep_blank_values)
+        except SystemError as er:
+            import urllib.parse
+            pairs = urllib.parse.parse_qsl(query_string, keep_blank_values)
+        return pairs
 
     def add_field(self, key, value):
         """Insert a field as key/value pair"""


### PR DESCRIPTION
On Python3, parse_qsl fails while decoding string to UTF8.
and Exception is raised when we run parse_qsl.

However in python3, urllib.parse module provides same function which works fine when compiled with python3.

signature of parse_qsl method from _apachemodule.c and urllib.parse is same and both provides same functionality.

Hence adding parse_qsl function from urllib.parse module as a fallback if an exception is raised from parse_qsl method from _apachemodule.c