### PR TITLE
Fix for incorrect configure python library variable

### DIFF
--- a/configure
+++ b/configure
@@ -3232,8 +3232,21 @@ if test "${PYTHONFRAMEWORKDIR}" = "no-framework"; then
         standard_lib=1) +"/config")'`
     LDFLAGS="${LDFLAGS1} ${LDFLAGS2}"
 
-    LDLIBS1=`${PYTHON_BIN} -c 'import distutils.sysconfig;\
-        print(distutils.sysconfig.get_config_var("LDLIBRARY"))'`
+    PYTHON_CODE=$(cat <<END
+import distutils.sysconfig
+lookingFor = "-lpython"
+ret = str(distutils.sysconfig.get_config_var("BLDLIBRARY"))
+if lookingFor not in ret:
+    cfg = distutils.sysconfig.get_config_vars()
+    for key in cfg:
+        if isinstance(cfg[key], str) and lookingFor in cfg[key]:
+            ret = cfg[key]
+            break
+print(ret[ret.find(lookingFor) if ret.find(lookingFor) != -1 else 0:])
+END
+)
+
+    LDLIBS1=`${PYTHON_BIN} -c "$PYTHON_CODE"` 
     LDLIBS2=`${PYTHON_BIN} -c 'from distutils import sysconfig; \
         print(sysconfig.get_config_var("LIBS"))'`
 


### PR DESCRIPTION
`BLDLIBRARY` isn't consistent depending on the how the original python got built. 
```
> python  -m sysconfig | grep BLDLIB
	BLDLIBRARY = "-L. -lpython2.7"
```
```
> python  -m sysconfig | grep BLDLIB
	BLDLIBRARY = ""
```
```
> python -m sysconfig | grep BLDLIB
	BLDLIBRARY = "libpython3.8.a"
```


-----
locally i've reverted the config code back to pre-ecbdcf17884551b823fcef12cd5bd91103bde1fc (nov 7, 2019)
```
+    if test "$PyMAJVERSION" -eq "3"; then
+        LDLIBS1="-lpython${PyMAJVERSION}"
+    else
+        LDLIBS1="-lpython${PyVERSION}"
+    fi
-    LDLIBS1=`${PYTHON_BIN} -c 'import distutils.sysconfig;\
-        print(distutils.sysconfig.get_config_var("LDLIBRARY"))'`
```

_Originally posted by @ewah in https://github.com/grisha/mod_python/issues/81#issuecomment-584414274_

Addressing the issue with python script.