### PR TITLE
Replace unbound method conditional

### DIFF
--- a/lib/python/mod_python/apache.py
+++ b/lib/python/mod_python/apache.py
@@ -24,6 +24,7 @@ import time
 import os
 import pdb
 import stat
+import inspect
 import importlib
 import types
 import _apache
@@ -693,9 +694,9 @@ def resolve_object(module, obj_str, arg=None, silent=0):
 
         obj = getattr(obj, obj_str)
 
-        if hasattr(obj, "im_self") and not obj.__self__:
-            # this is an unbound method, its class
-            # needs to be instantiated
+        if inspect.isclass(parent):
+            # The parent of this object is a class,
+            # it needs to be instantiated
             instance = parent(arg)
             obj = getattr(instance, obj_str)
 


### PR DESCRIPTION
The concept of 'unbound methods' has been removed from python with 3.0 [[1]](https://docs.python.org/3.0/whatsnew/3.0.html#operators-and-special-methods).
There is no difference between uninstantiated class methods and functions.
This means that the check in `apache.py` `resolve_object` does not work in Python 3. 
So mod_python doesn't instantiate classes in handler objects.

Instead check if the parent object is a class and instantiate it if it is.
This is more in line with what the documentation tells ("During resolution, if mod_python encounters an object of type `<class>`, it will try instantiating it passing it a single argument, a request object." [[2]](http://modpython.org/live/current/doc-html/directives.html#python-handler-directive-syntax))

It works with both Python 2 (2.7 tested) and Python 3 (3.9 tested).