### PR TITLE
Add 'samesite' to valid cookie attrs

### DIFF
--- a/lib/python/mod_python/Cookie.py
+++ b/lib/python/mod_python/Cookie.py
@@ -59,7 +59,7 @@ class metaCookie(type):
 
         _valid_attr = (
             "version", "path", "domain", "secure",
-            "comment", "expires", "max_age",
+            "comment", "expires", "max_age", "samesite",
             # RFC 2965
             "commentURL", "discard", "port",
             # Microsoft Extension


### PR DESCRIPTION
Although the rfc is still in draft [[1]](https://tools.ietf.org/id/draft-ietf-httpbis-rfc6265bis-03.html#rfc.section.5.3.7) the `SameSite` attribute is widely used and is required in many cases [[2]](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite).
This adds `samesite` to the valid cookie attributes.