### PR TITLE
Don't use obsolete egrep

### DIFF
--- a/configure
+++ b/configure
@@ -3040,7 +3040,7 @@ $as_echo_n "checking Apache version... " >&6; }
 $as_echo "$HTTPD_VERSION" >&6; }
 
   # make sure version begins with 2
-  if test -z "`echo $HTTPD_VERSION | egrep \^2`"; then
+  if test -z "`echo $HTTPD_VERSION | grep -E \^2`"; then
     as_fn_error $? "This version of mod_python only works with Apache 2. The one we have ($HTTPD) seems to be $HTTPD_VERSION." "$LINENO" 5
   fi
 

--- a/configure.in
+++ b/configure.in
@@ -81,7 +81,7 @@ else
   AC_MSG_RESULT($HTTPD_VERSION)
 
   # make sure version begins with 2
-  if test -z "`echo $HTTPD_VERSION | egrep \^2`"; then
+  if test -z "`echo $HTTPD_VERSION | grep -E \^2`"; then
     AC_MSG_ERROR([This version of mod_python only works with Apache 2. The one we have ($HTTPD) seems to be $HTTPD_VERSION.])
   fi
 


### PR DESCRIPTION
From grep 3.8 release notes https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html

```
  The egrep and fgrep commands, which have been deprecated since
  release 2.5.3 (2007), now warn that they are obsolescent and should
  be replaced by grep -E and grep -F.
```