### PR TITLE
Fix re expression SyntaxWarning in cache.py

### DIFF
--- a/lib/python/mod_python/cache.py
+++ b/lib/python/mod_python/cache.py
@@ -280,7 +280,7 @@ class FileCache(Cache):
 def parseRFC822Time(t):
     return mktime(parsedate(t))
 
-re_max_age=re.compile('max-age\s*=\s*(\d+)', re.I)
+re_max_age=re.compile(r'max-age\s*=\s*(\d+)', re.I)
 
 class HTTPEntity(object):
     def __init__(self, entity, metadata):


### PR DESCRIPTION
The regular expression in lib/python/mod_python/cache.py contains invalid escape sequences. The escape character (`\` aka backslash) of regular expressions collides with the escape character (also `\` aka backslash) of Python string literals.

Since Python 3.12 any invalid escape sequences in Python's usage of the backslash in string literals now generate a SyntaxWarning and in the future this will become a SyntaxError. Previous Python versions also noted similar future deprecation warnings.

See https://docs.python.org/3.12/library/re.html for more details.